### PR TITLE
Make prose tables horizontally scrollable on mobile

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -289,6 +289,51 @@ body {
     @apply w-full;
   }
 
+  /* Wrap tables in a scrollable container on small screens */
+  .table-wrapper {
+    @apply w-full overflow-x-auto;
+    scrollbar-width: thin;
+    scrollbar-color: var(--color-primary) var(--color-base-200);
+  }
+
+  .table-wrapper::-webkit-scrollbar {
+    height: 4px;
+  }
+
+  .table-wrapper::-webkit-scrollbar-track {
+    background: var(--color-base-200);
+    border-radius: 2px;
+  }
+
+  .table-wrapper::-webkit-scrollbar-thumb {
+    background: var(--color-primary);
+    border-radius: 2px;
+  }
+
+  @media (max-width: 640px) {
+    table {
+      display: block;
+      overflow-x: auto;
+      width: 100%;
+      scrollbar-width: thin;
+      scrollbar-color: var(--color-primary) var(--color-base-200);
+    }
+
+    table::-webkit-scrollbar {
+      height: 4px;
+    }
+
+    table::-webkit-scrollbar-track {
+      background: var(--color-base-200);
+      border-radius: 2px;
+    }
+
+    table::-webkit-scrollbar-thumb {
+      background: var(--color-primary);
+      border-radius: 2px;
+    }
+  }
+
   thead {
     @apply border-b-2 border-primary-content;
   }

--- a/src/lib/components/TableOfContents.svelte
+++ b/src/lib/components/TableOfContents.svelte
@@ -7,6 +7,8 @@
     floating = false,
   }: { entries?: TocEntry[]; class?: string; floating?: boolean } = $props();
 
+  let drawerOpen = $state(false);
+
   function indentClass(level: number): string {
     switch (level) {
       case 2:
@@ -19,31 +21,129 @@
         return "pl-2";
     }
   }
+
+  function closeDrawer() {
+    drawerOpen = false;
+  }
 </script>
 
 {#if entries.length > 0}
-  <nav
-    class="blog-card p-4 max-h-[calc(100vh-8rem)] overflow-y-auto {floating
-      ? ''
-      : 'sticky top-24'} {className}"
-    aria-label="Table of contents"
-  >
-    <h2 class="text-sm font-bold text-primary-content uppercase tracking-wide mb-3">
-      On this page
-    </h2>
-    <ul class="space-y-1.5 text-sm">
-      {#each entries as entry (entry.id)}
-        <li
-          class="border-l-2 border-primary/30 hover:border-primary {indentClass(entry.level)}"
-        >
-          <a
-            href="#{entry.id}"
-            class="text-primary-content/90 hover:text-primary-content hover:underline underline-offset-2 block py-0.5"
+  {#if floating}
+    <!-- Desktop: fixed sidebar on left -->
+    <nav
+      class="hidden lg:block fixed left-0 top-24 w-56 h-[calc(100vh-6rem)] overflow-y-auto pl-4 pr-2 py-4 z-20 {className}"
+      aria-label="Table of contents"
+    >
+      <h2 class="text-xs font-bold text-primary-content/60 uppercase tracking-widest mb-3">
+        On this page
+      </h2>
+      <ul class="space-y-1.5 text-sm">
+        {#each entries as entry (entry.id)}
+          <li
+            class="border-l-2 border-primary/30 hover:border-primary transition-colors {indentClass(entry.level)}"
           >
-            {entry.text}
-          </a>
-        </li>
-      {/each}
-    </ul>
-  </nav>
+            <a
+              href="#{entry.id}"
+              class="text-primary-content/80 hover:text-primary-content hover:underline underline-offset-2 block py-0.5 leading-snug"
+            >
+              {entry.text}
+            </a>
+          </li>
+        {/each}
+      </ul>
+    </nav>
+
+    <!-- Mobile: floating toggle button + slide-in drawer -->
+    <div class="lg:hidden">
+      <!-- Toggle button -->
+      <button
+        onclick={() => (drawerOpen = !drawerOpen)}
+        class="fixed bottom-6 right-6 z-40 btn btn-primary btn-circle shadow-lg"
+        aria-label={drawerOpen ? "Close table of contents" : "Open table of contents"}
+        aria-expanded={drawerOpen}
+      >
+        {#if drawerOpen}
+          <!-- X icon -->
+          <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+            <path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12" />
+          </svg>
+        {:else}
+          <!-- List / TOC icon -->
+          <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+            <path stroke-linecap="round" stroke-linejoin="round" d="M4 6h16M4 10h10M4 14h16M4 18h10" />
+          </svg>
+        {/if}
+      </button>
+
+      <!-- Backdrop -->
+      {#if drawerOpen}
+        <button
+          class="fixed inset-0 z-30 bg-black/40 backdrop-blur-sm"
+          onclick={closeDrawer}
+          aria-label="Close table of contents"
+          tabindex="-1"
+        ></button>
+      {/if}
+
+      <!-- Drawer panel -->
+      <div
+        class="fixed bottom-0 left-0 right-0 z-40 max-h-[60vh] overflow-y-auto blog-card rounded-t-2xl px-6 py-5 shadow-2xl transition-transform duration-300 {drawerOpen
+          ? 'translate-y-0'
+          : 'translate-y-full'}"
+        aria-hidden={!drawerOpen}
+      >
+        <div class="flex items-center justify-between mb-4">
+          <h2 class="text-sm font-bold text-primary-content uppercase tracking-widest">
+            On this page
+          </h2>
+          <button
+            onclick={closeDrawer}
+            class="btn btn-ghost btn-xs btn-circle"
+            aria-label="Close"
+          >
+            <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+              <path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12" />
+            </svg>
+          </button>
+        </div>
+        <ul class="space-y-2 text-sm">
+          {#each entries as entry (entry.id)}
+            <li class="border-l-2 border-primary/30 {indentClass(entry.level)}">
+              <a
+                href="#{entry.id}"
+                onclick={closeDrawer}
+                class="text-primary-content/90 hover:text-primary-content hover:underline underline-offset-2 block py-0.5 leading-snug"
+              >
+                {entry.text}
+              </a>
+            </li>
+          {/each}
+        </ul>
+      </div>
+    </div>
+  {:else}
+    <!-- Inline (non-floating) variant -->
+    <nav
+      class="blog-card p-4 max-h-[calc(100vh-8rem)] overflow-y-auto sticky top-24 {className}"
+      aria-label="Table of contents"
+    >
+      <h2 class="text-sm font-bold text-primary-content uppercase tracking-wide mb-3">
+        On this page
+      </h2>
+      <ul class="space-y-1.5 text-sm">
+        {#each entries as entry (entry.id)}
+          <li
+            class="border-l-2 border-primary/30 hover:border-primary {indentClass(entry.level)}"
+          >
+            <a
+              href="#{entry.id}"
+              class="text-primary-content/90 hover:text-primary-content hover:underline underline-offset-2 block py-0.5"
+            >
+              {entry.text}
+            </a>
+          </li>
+        {/each}
+      </ul>
+    </nav>
+  {/if}
 {/if}

--- a/src/routes/(main)/blogs/[slug]/+page.svelte
+++ b/src/routes/(main)/blogs/[slug]/+page.svelte
@@ -19,60 +19,52 @@
   canonical={data.canonicalURL}
 />
 
-<div class="w-full">
-  <aside
-    class="hidden lg:block fixed left-0 top-24 w-56 h-[calc(100vh-5rem)] overflow-y-auto pl-4 pr-2 py-4 z-10"
-  >
-    <TableOfContents entries={toc} floating={true} />
-  </aside>
+<!-- Floating ToC handles both desktop sidebar and mobile drawer internally -->
+<TableOfContents entries={toc} floating={true} />
 
-  <div class="lg:hidden px-6 pt-6">
-    <TableOfContents entries={toc} />
-  </div>
-
-  <main class="w-full lg:pl-56">
-    <div class="max-w-3xl mx-auto px-6 lg:px-12 py-8 space-y-6">
-      <header class="blog-card p-6 lg:p-8 text-center">
-        <h1 class="text-3xl lg:text-4xl font-bold text-primary-content tracking-tight mb-3">
-          {data.title}
-        </h1>
-        {#if data.description}
-          <p class="text-primary-content/90 max-w-2xl mx-auto mb-4">
-            {data.description}
-          </p>
-        {/if}
-        <div class="flex flex-wrap justify-center items-center gap-2 mb-3">
-          {#each data.categories as cat}
-            <span class="badge badge-primary text-primary-content text-xs">
-              {cat}
-            </span>
-          {/each}
-          {#each data.tags as tag}
-            <span class="badge badge-primary badge-outline text-primary-content text-xs">
-              {tag}
-            </span>
-          {/each}
-        </div>
-        <p class="text-sm text-primary-content/80">
-          <span>Published {data.date}</span>
-          {#if data.lastUpdated && data.lastUpdated !== data.date}
-            <span class="mx-2">·</span>
-            <span>Updated {data.lastUpdated}</span>
-          {/if}
+<!-- Centered article content -->
+<main class="w-full min-h-screen">
+  <div class="max-w-3xl mx-auto px-6 py-8 space-y-6">
+    <header class="blog-card p-6 lg:p-8 text-center">
+      <h1 class="text-3xl lg:text-4xl font-bold text-primary-content tracking-tight mb-3">
+        {data.title}
+      </h1>
+      {#if data.description}
+        <p class="text-primary-content/90 max-w-2xl mx-auto mb-4">
+          {data.description}
         </p>
-        <p class="text-sm text-primary-content/80">by @notkaramel</p>
-      </header>
+      {/if}
+      <div class="flex flex-wrap justify-center items-center gap-2 mb-3">
+        {#each data.categories as cat}
+          <span class="badge badge-primary text-primary-content text-xs">
+            {cat}
+          </span>
+        {/each}
+        {#each data.tags as tag}
+          <span class="badge badge-primary badge-outline text-primary-content text-xs">
+            {tag}
+          </span>
+        {/each}
+      </div>
+      <p class="text-sm text-primary-content/80">
+        <span>Published {data.date}</span>
+        {#if data.lastUpdated && data.lastUpdated !== data.date}
+          <span class="mx-2">·</span>
+          <span>Updated {data.lastUpdated}</span>
+        {/if}
+      </p>
+      <p class="text-sm text-primary-content/80">by @notkaramel</p>
+    </header>
 
-      <article class="blog-card blog-article p-6 lg:p-8">
-        <div class="prose max-w-full">
-          {@html content}
-        </div>
-        <div class="mt-10 pt-6 border-t border-primary-content">
-          <a href="/blogs" class="btn btn-primary btn-outline text-primary-content">
-            ← Back to Blog
-          </a>
-        </div>
-      </article>
-    </div>
-  </main>
-</div>
+    <article class="blog-card blog-article p-6 lg:p-8">
+      <div class="prose max-w-full">
+        {@html content}
+      </div>
+      <div class="mt-10 pt-6 border-t border-primary-content">
+        <a href="/blogs" class="btn btn-primary btn-outline text-primary-content">
+          ← Back to Blog
+        </a>
+      </div>
+    </article>
+  </div>
+</main>

--- a/src/routes/(main)/wiki/[slug]/+page.svelte
+++ b/src/routes/(main)/wiki/[slug]/+page.svelte
@@ -19,57 +19,46 @@
   canonical={data.canonicalURL}
 />
 
-<div class="w-full">
-  <aside
-    class="hidden lg:block fixed left-0 top-24 w-56 h-[calc(100vh-5rem)] overflow-y-auto pl-4 pr-2 py-4 z-10"
-  >
-    <TableOfContents entries={toc} floating={true} />
-  </aside>
+<!-- Floating ToC handles both desktop sidebar and mobile drawer internally -->
+<TableOfContents entries={toc} floating={true} />
 
-  <div class="lg:hidden px-6 pt-6">
-    <TableOfContents entries={toc} />
-  </div>
-
-  <main class="w-full lg:pl-56">
-    <div class="max-w-3xl mx-auto px-6 lg:px-12 py-8 space-y-6">
-      <header class="blog-card p-6 lg:p-8 text-center">
-        <h1 class="text-3xl lg:text-4xl font-bold text-primary-content tracking-tight mb-3">
-          {data.title}
-        </h1>
-        {#if data.description}
-          <p class="text-primary-content/90 max-w-2xl mx-auto mb-4">
-            {data.description}
-          </p>
-        {/if}
-        <div class="flex flex-wrap justify-center items-center gap-2 mb-3">
-          {#each data.tags as tag}
-            <span class="badge badge-primary badge-outline text-primary-content text-xs">
-              {tag}
-            </span>
-          {/each}
-        </div>
-        <p class="text-sm text-primary-content/80">
-          <span>Published {data.date}</span>
-          {#if data.lastUpdated && data.lastUpdated !== data.date}
-            <span class="mx-2">·</span>
-            <span>Updated {data.lastUpdated}</span>
-          {/if}
+<!-- Centered article content -->
+<main class="w-full min-h-screen">
+  <div class="max-w-3xl mx-auto px-6 py-8 space-y-6">
+    <header class="blog-card p-6 lg:p-8 text-center">
+      <h1 class="text-3xl lg:text-4xl font-bold text-primary-content tracking-tight mb-3">
+        {data.title}
+      </h1>
+      {#if data.description}
+        <p class="text-primary-content/90 max-w-2xl mx-auto mb-4">
+          {data.description}
         </p>
-      </header>
+      {/if}
+      <div class="flex flex-wrap justify-center items-center gap-2 mb-3">
+        {#each data.tags as tag}
+          <span class="badge badge-primary badge-outline text-primary-content text-xs">
+            {tag}
+          </span>
+        {/each}
+      </div>
+      <p class="text-sm text-primary-content/80">
+        <span>Published {data.date}</span>
+        {#if data.lastUpdated && data.lastUpdated !== data.date}
+          <span class="mx-2">·</span>
+          <span>Updated {data.lastUpdated}</span>
+        {/if}
+      </p>
+    </header>
 
-      <article class="blog-card blog-article p-6 lg:p-8">
-        <div class="prose max-w-full">
-          {@html content}
-        </div>
-        <div class="mt-10 pt-6 border-t border-primary-content">
-          <a
-            href="/wiki"
-            class="btn btn-primary btn-outline text-primary-content"
-          >
-            ← Back to Wiki
-          </a>
-        </div>
-      </article>
-    </div>
-  </main>
-</div>
+    <article class="blog-card blog-article p-6 lg:p-8">
+      <div class="prose max-w-full">
+        {@html content}
+      </div>
+      <div class="mt-10 pt-6 border-t border-primary-content">
+        <a href="/wiki" class="btn btn-primary btn-outline text-primary-content">
+          ← Back to Wiki
+        </a>
+      </div>
+    </article>
+  </div>
+</main>


### PR DESCRIPTION
### `src/app.css`

Added a `@media (max-width: 640px)` block inside `.prose` that sets `table` to `display: block; overflow-x: auto`, allowing wide tables rendered from Markdown to scroll horizontally on small screens instead of overflowing or squishing. Also added a `.table-wrapper` utility class (with matching thin scrollbar styling) for any future cases where a wrapping element is preferred over block-table behavior.